### PR TITLE
Rename DeviceInfo to DeviceSpecs to remove conflict

### DIFF
--- a/src/DefaultMapControls.qml
+++ b/src/DefaultMapControls.qml
@@ -23,7 +23,7 @@ Item {
         iconName: "ios-add-circle-outline"
         anchors.right: parent.right
         anchors.verticalCenter: parent.verticalCenter
-        anchors.verticalCenterOffset: - height/2 + DeviceInfo.flatTireHeight/2
+        anchors.verticalCenterOffset: - height/2 + DeviceSpecs.flatTireHeight/2
         height: parent.height*0.2
         width: height
         iconColor: colors.primary
@@ -34,7 +34,7 @@ Item {
         iconName: "ios-remove-circle-outline"
         anchors.right: parent.right
         anchors.verticalCenter: parent.verticalCenter
-        anchors.verticalCenterOffset: height/2 + DeviceInfo.flatTireHeight/2
+        anchors.verticalCenterOffset: height/2 + DeviceSpecs.flatTireHeight/2
         height: parent.height*0.2
         width: height
         iconColor: colors.primary
@@ -44,7 +44,7 @@ Item {
     MouseArea {
         anchors.left: parent.left
         anchors.verticalCenter: parent.verticalCenter
-        anchors.verticalCenterOffset: - height/2 + DeviceInfo.flatTireHeight/2
+        anchors.verticalCenterOffset: - height/2 + DeviceSpecs.flatTireHeight/2
         height: parent.height*0.2
         width: height
         z: 2
@@ -64,7 +64,7 @@ Item {
     IconButton {
         iconName: "ios-locate-outline"
         anchors.verticalCenter: parent.verticalCenter
-        anchors.verticalCenterOffset: height/2 + DeviceInfo.flatTireHeight/2
+        anchors.verticalCenterOffset: height/2 + DeviceSpecs.flatTireHeight/2
         anchors.left: parent.left
         height: parent.height*0.2
         width: height

--- a/src/SetPointMapControls.qml
+++ b/src/SetPointMapControls.qml
@@ -26,7 +26,7 @@ Item {
         iconName: "ios-add-circle-outline"
         anchors.right: parent.right
         anchors.verticalCenter: parent.verticalCenter
-        anchors.verticalCenterOffset: - height/2 + DeviceInfo.flatTireHeight/2
+        anchors.verticalCenterOffset: - height/2 + DeviceSpecs.flatTireHeight/2
         height: parent.height*0.2
         width: height
         iconColor: colors.primary
@@ -37,7 +37,7 @@ Item {
         iconName: "ios-remove-circle-outline"
         anchors.right: parent.right
         anchors.verticalCenter: parent.verticalCenter
-        anchors.verticalCenterOffset: height/2 + DeviceInfo.flatTireHeight/2
+        anchors.verticalCenterOffset: height/2 + DeviceSpecs.flatTireHeight/2
         height: parent.height*0.2
         width: height
         iconColor: colors.primary
@@ -47,7 +47,7 @@ Item {
     MouseArea {
         anchors.left: parent.left
         anchors.verticalCenter: parent.verticalCenter
-        anchors.verticalCenterOffset: - height/2 + DeviceInfo.flatTireHeight/2
+        anchors.verticalCenterOffset: - height/2 + DeviceSpecs.flatTireHeight/2
         height: parent.height*0.2
         width: height
         z: 2
@@ -68,7 +68,7 @@ Item {
         iconName: "ios-locate-outline"
         anchors.left: parent.left
         anchors.verticalCenter: parent.verticalCenter
-        anchors.verticalCenterOffset: height/2 + DeviceInfo.flatTireHeight/2
+        anchors.verticalCenterOffset: height/2 + DeviceSpecs.flatTireHeight/2
         height: parent.height*0.2
         width: height
         iconColor: colors.primary


### PR DESCRIPTION
This renames the DeviceInfo QML class in org.asteroid.utils to DeviceSpecs to avoid a conflict with an unrelated DeviceInfo class defined in org.nemomobile.systemsettings.

This fixes AsteroidOS/qml-asteroid#56